### PR TITLE
Update repoman-travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,27 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.2.28"
+    - PORTAGE_VER="2.3.8"
+before_install:
+    - sudo apt-get -qq update
+    - pip install lxml
 before_script:
-    - mkdir travis-overlay
+    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr
+    - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
-    - wget "https://github.com/gentoo/portage/archive/v${PORTAGE_VER}.tar.gz" -O portage-${PORTAGE_VER}.tar.gz
-    - wget "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" -O portage-tree.tar.gz
-    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr spinner.sh
+    - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
+    - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
     - chmod a+rwx spinner.sh
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
-    - mkdir -p /etc/portage /usr/portage/distfiles
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
-    - tar xzf portage-${PORTAGE_VER}.tar.gz
-    - tar xzf portage-tree.tar.gz -C /usr/portage --strip-components=1
-    - cp portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/
-    - ln -s /usr/portage/profiles/base/ /etc/portage/make.profile
+    - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
+    - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay
 script:
-    - ./../spinner.sh "python ../portage-${PORTAGE_VER}/bin/repoman full -d"
+    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d"


### PR DESCRIPTION
This updates to the latest version of repoman-travis, maintaining changes that were originally in DamnWidget's .travis.yml. This is the update mentioned by the build script.

This pull request should fix the rest of the build errors - see https://travis-ci.org/daboross/sublime-text/builds/275302472.